### PR TITLE
Issue #2641576: Recurly plan names are improperly encoded 

### DIFF
--- a/src/Form/RecurlySubscriptionPlansForm.php
+++ b/src/Form/RecurlySubscriptionPlansForm.php
@@ -126,12 +126,12 @@ class RecurlySubscriptionPlansForm extends FormBase {
       $description = '';
       // Prepare the description string if one is given for the plan.
       if (!empty($plan->description)) {
-        $description = '<div class="description">' . nl2br(SafeMarkup::checkPlain($plan->description)) . '</div>';
+        $description = $this->t('<div class="description">@description</div>', ['@description' => $plan->description]);
       }
 
       $form['recurly_subscription_plans'][$plan_code]['#title_display'] = 'none';
       $options[$plan_code] = [
-        'plan_title' => SafeMarkup::checkPlain($plan->name) . ' <small>(' . SafeMarkup::checkPlain($plan_code) . ')</small>' . $description,
+        'plan_title' => $this->t('@planname <small>(@plancode)</small> @description', ['@planname' => $plan->name, '@plancode' => $plan_code, '@description' => $description]),
         'price' => implode('<br />', $plan_details['unit_amounts']),
         'setup_fee' => implode('<br />', $plan_details['setup_amounts']),
         'trial' => $plan->trial_interval_length ? $this->t('@trial_length @trial_unit', ['@trial_length' => $plan->trial_interval_length, '@trial_unit' => $plan->trial_interval_unit]) : $this->t('No trial'),


### PR DESCRIPTION
Recurly plan names are improperly encoded on subscription plans page. Drupal issue: https://www.drupal.org/node/2641576

Drupal 8's rendering and its wide array of options made understanding what's best here a lot more confusing (plus the fact that they've already deprecated half the new stuff), but it looks like good old `t()` is still the best bet for sanitizing text with a small amount of markup.

<img width="1457" alt="2015-12-29_1455" src="https://cloud.githubusercontent.com/assets/1540998/12043879/4933c742-ae3e-11e5-9c90-89eca19c137d.png">

@CHROMATIC-LLC/recurly 
