### PR TITLE
Refactor RecurlyUrlManager to return Url object instead of string.

### DIFF
--- a/modules/recurly_hosted/recurly_hosted.module
+++ b/modules/recurly_hosted/recurly_hosted.module
@@ -35,7 +35,7 @@ function recurly_hosted_recurly_url_info($operation, $context) {
  */
 function recurly_hosted_account_edit_url($recurly_account) {
   $recurly_url_manager = \Drupal::service('recurly.url_manager');
-  return $recurly_url_manager->hostedUrl('accounts/' . $recurly_account->account_code);
+  return $recurly_url_manager->hostedUrl('accounts/' . $recurly_account->account_code)->getUri();
 }
 
 /**
@@ -55,9 +55,9 @@ function recurly_hosted_account_manage_url($recurly_account, $hosted_login_token
   $recurly_url_manager = \Drupal::service('recurly.url_manager');
   // Return a Url using the hosted login token if available.
   if ($hosted_login_token && !empty($recurly_account->hosted_login_token)) {
-    return $recurly_url_manager->hostedUrl('account/' . $recurly_account->hosted_login_token);
+    return $recurly_url_manager->hostedUrl('account/' . $recurly_account->hosted_login_token)->getUri();
   }
-  return $recurly_url_manager->hostedUrl('account');
+  return $recurly_url_manager->hostedUrl('account')->getUri();
 }
 
 /**
@@ -94,5 +94,5 @@ function recurly_hosted_subscription_plan_purchase_url($plan_code, $account_code
   }
 
   $recurly_url_manager = \Drupal::service('recurly.url_manager');
-  return $recurly_url_manager->hostedUrl($url);
+  return $recurly_url_manager->hostedUrl($url)->getUri();
 }

--- a/modules/recurlyjs/recurlyjs.module
+++ b/modules/recurlyjs/recurlyjs.module
@@ -64,7 +64,8 @@ function _recurlyjs_form_recurly_settings_form_alter(&$form, FormStateInterface 
   $recurly_url_manager = \Drupal::service('recurly.url_manager');
   $recurly_account_link_text = t('your Recurly account');
   if (\Drupal::config('recurly.settings')->get('recurly_subdomain')) {
-    $recurly_account_link = '<a href="' . Url::fromUri($recurly_url_manager->hostedUrl('configuration/edit'))->toString() . '">' . $recurly_account_link_text . '</a>';
+    $url = Url::fromUri($recurly_url_manager->hostedUrl('configuration/edit')->getUri())->toString();
+    $recurly_account_link = '<a href="' . Url::fromUri($recurly_url_manager->hostedUrl('configuration/edit')->getUri())->toString() . '">' . $recurly_account_link_text . '</a>';
   }
   else {
     $recurly_account_link = $recurly_account_link_text;

--- a/recurly.module
+++ b/recurly.module
@@ -573,7 +573,7 @@ function recurly_subscription_plans($reset_cache = FALSE) {
  */
 function recurly_subscription_plan_edit_url($plan) {
   $recurly_url_manager = \Drupal::service('recurly.url_manager');
-  return $recurly_url_manager->hostedUrl('company/plans/' . $plan->plan_code);
+  return $recurly_url_manager->hostedUrl('company/plans/' . $plan->plan_code)->getUri();
 }
 
 /**

--- a/src/Form/RecurlySettingsForm.php
+++ b/src/Form/RecurlySettingsForm.php
@@ -72,7 +72,7 @@ class RecurlySettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Default currency'),
       '#description' => $this->t('Enter the 3-character currency code for the currency you would like to use by default. You can find a list of supported currencies in your <a href="!url">Recurly account currencies page</a>.', [
-        '!url' => $recurly_url_manager->hostedUrl('configuration/currencies'),
+        '!url' => $recurly_url_manager->hostedUrl('configuration/currencies')->getUri(),
       ]),
       '#default_value' => \Drupal::config('recurly.settings')->get('recurly_default_currency'),
       '#size' => 3,

--- a/src/Form/RecurlySubscriptionPlansForm.php
+++ b/src/Form/RecurlySubscriptionPlansForm.php
@@ -145,7 +145,7 @@ class RecurlySubscriptionPlansForm extends FormBase {
       '#type' => 'tableselect',
       '#header' => $header,
       '#options' => $options,
-      '#empty' => $this->t('No subscription plans found. You can start by creating one in <a href=":url">your Recurly account</a>.', [':url' => \Drupal::config('recurly.settings')->get('recurly_subdomain') ? $recurly_url_manager->hostedUrl('plans') : 'http://app.recurly.com']),
+      '#empty' => $this->t('No subscription plans found. You can start by creating one in <a href=":url">your Recurly account</a>.', [':url' => \Drupal::config('recurly.settings')->get('recurly_subdomain') ? $recurly_url_manager->hostedUrl('plans')->getUri() : 'http://app.recurly.com']),
       '#js_select' => FALSE,
       '#default_value' => $existing_plans,
       '#multiple' => TRUE,

--- a/src/Plugin/views/field/AccountCode.php
+++ b/src/Plugin/views/field/AccountCode.php
@@ -67,7 +67,7 @@ class AccountCode extends FieldPluginBase {
     if (!empty($this->options['link_to_recurly']) && ($account_code = $this->getValue($values)) && $data !== NULL && $data !== '') {
       $this->options['alter']['make_link'] = TRUE;
       $recurly_url_manager = \Drupal::service('recurly.url_manager');
-      $this->options['alter']['path'] = $recurly_url_manager->hostedUrl('accounts/' . $account_code);
+      $this->options['alter']['path'] = $recurly_url_manager->hostedUrl('accounts/' . $account_code)->getUri();
     }
     return $data;
   }

--- a/src/RecurlyUrlManager.php
+++ b/src/RecurlyUrlManager.php
@@ -17,8 +17,8 @@ class RecurlyUrlManager {
    * @param $subdomain $string
    *   A subdomain string.
    *
-   * @return string
-   *   The Recurly URL for the current account w/optional path appended.
+   * @return \Drupal\Core\Url
+   *   Returns a \Drupal\Core\Url object.
    */
   public function hostedUrl($path = '', $subdomain = NULL) {
     if (!$subdomain) {

--- a/src/RecurlyUrlManager.php
+++ b/src/RecurlyUrlManager.php
@@ -25,6 +25,6 @@ class RecurlyUrlManager {
       $subdomain = \Drupal::config('recurly.settings')->get('recurly_subdomain');
     }
 
-    return \Drupal\Core\Url::fromUri('https://' . $subdomain . '.recurly.com/' . $path)->getUri();
+    return \Drupal\Core\Url::fromUri('https://' . $subdomain . '.recurly.com/' . $path);
   }
 }

--- a/src/Tests/RecurlyUrlManagerTest.php
+++ b/src/Tests/RecurlyUrlManagerTest.php
@@ -23,7 +23,7 @@ class RecurlyUrlManagerTest extends UnitTestCase {
    */
   public function testHostedUrl() {
     $recurly_url_manager = new RecurlyUrlManager();
-    $hosted_url = $recurly_url_manager->hostedUrl('configuration/currencies', 'sub-domain');
+    $hosted_url = $recurly_url_manager->hostedUrl('configuration/currencies', 'sub-domain')->getUri();
     $this->assertEquals($hosted_url, 'https://sub-domain.recurly.com/configuration/currencies');
   }
 }


### PR DESCRIPTION
Issue: https://www.drupal.org/node/2642120

Refactored RecurlyUrlManager::hostedUrl to return Drupal/Core/Url Object. I then found all instances in the code that called that method and chained Drupal/Core/Url::getUri.
