### PR TITLE
Register RecurlyFormatManager service and use it

### DIFF
--- a/recurly.services.yml
+++ b/recurly.services.yml
@@ -25,3 +25,5 @@ services:
     arguments: ['@entity.manager']
     tags:
       - { name: event_subscriber }
+  recurly.format_manager:
+    class: Drupal\recurly\RecurlyFormatManager

--- a/src/Controller/RecurlySubscriptionListController.php
+++ b/src/Controller/RecurlySubscriptionListController.php
@@ -16,11 +16,39 @@ use Drupal\Core\Url;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\recurly\RecurlyFormatManager;
 
 /**
  * Returns responses for Recurly Subscription List.
  */
 class RecurlySubscriptionListController extends ControllerBase {
+
+  /**
+   * The formatting service.
+   *
+   * @var \Drupal\recurly\RecurlyFormatManager
+   */
+  protected $formatter;
+
+  /**
+   * Constructs a \Drupal\recurly\Controller\RecurlySubscriptionListController object.
+   *
+   * @param \Drupal\recurly\RecurlyFormatManager $formatter
+   *   The Recurly formatter to be used for formatting.
+   */
+  public function __construct(RecurlyFormatManager $recurly_formatter) {
+    $this->formatter = $recurly_formatter;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('recurly.format_manager')
+    );
+  }
 
   /**
    * Route title callback.
@@ -100,7 +128,7 @@ class RecurlySubscriptionListController extends ControllerBase {
           'add_on_code' => $add_on->add_on_code,
           'name' => SafeMarkup::checkPlain($full_add_on->name),
           'quantity' => SafeMarkup::checkPlain($add_on->quantity),
-          'cost' => recurly_format_currency($add_on->unit_amount_in_cents, $subscription->currency),
+          'cost' => $this->formatter->formatCurrency($add_on->unit_amount_in_cents, $subscription->currency),
         ];
         $total += $add_on->unit_amount_in_cents * $add_on->quantity;
       }
@@ -120,16 +148,16 @@ class RecurlySubscriptionListController extends ControllerBase {
         '#plan_code' => $plan->plan_code,
         '#plan_name' => SafeMarkup::checkPlain($plan->name),
         '#state_array' => $states,
-        '#state_status' => recurly_format_state(reset($states)),
+        '#state_status' => $this->formatter->formatState(reset($states)),
         '#period_end_header' => $this->periodEndHeaderString($states),
-        '#cost' => recurly_format_currency($subscription->unit_amount_in_cents, $subscription->currency),
+        '#cost' => $this->formatter->formatCurrency($subscription->unit_amount_in_cents, $subscription->currency),
         '#quantity' => $subscription->quantity,
         '#add_ons' => $add_ons,
-        '#start_date' => recurly_format_date($subscription->activated_at),
-        '#end_date' => isset($subscription->expires_at) ? recurly_format_date($subscription->expires_at) : NULL,
-        '#current_period_start' => recurly_format_date($subscription->current_period_started_at),
-        '#current_period_ends_at' => recurly_format_date($subscription->current_period_ends_at),
-        '#total' => recurly_format_currency($total, $subscription->currency),
+        '#start_date' => $this->formatter->formatDate($subscription->activated_at),
+        '#end_date' => isset($subscription->expires_at) ? $this->formatter->formatDate($subscription->expires_at) : NULL,
+        '#current_period_start' => $this->formatter->formatDate($subscription->current_period_started_at),
+        '#current_period_ends_at' => $this->formatter->formatDate($subscription->current_period_ends_at),
+        '#total' => $this->formatter->formatCurrency($total, $subscription->currency),
         '#subscription_links' => [
           '#theme' => 'links',
           '#links' => $links,
@@ -236,7 +264,7 @@ class RecurlySubscriptionListController extends ControllerBase {
           return $this->t('This plan has expired.');
         }
       case 'pending_subscription':
-        return $this->t('This plan will be changed to @plan on @date.', ['@plan' => $context['subscription']->pending_subscription->plan->name, '@date' => recurly_format_date($context['subscription']->current_period_ends_at)]);
+        return $this->t('This plan will be changed to @plan on @date.', ['@plan' => $context['subscription']->pending_subscription->plan->name, '@date' => $this->formatter->formatDate($context['subscription']->current_period_ends_at)]);
 
       case 'future':
         return $this->t('This plan has not started yet. Please contact support if you have any questions.');

--- a/src/Form/RecurlyRedeemCouponForm.php
+++ b/src/Form/RecurlyRedeemCouponForm.php
@@ -10,11 +10,39 @@ namespace Drupal\recurly\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\recurly\RecurlyFormatManager;
 
 /**
  * Recurly redeem coupon form.
  */
 class RecurlyRedeemCouponForm extends FormBase {
+
+  /**
+   * The formatting service.
+   *
+   * @var \Drupal\recurly\RecurlyFormatManager
+   */
+  protected $formatter;
+
+  /**
+   * Constructs a \Drupal\recurly\Form\RecurlyRedeemCouponForm object.
+   *
+   * @param \Drupal\recurly\RecurlyFormatManager $formatter
+   *   The Recurly formatter to be used for formatting.
+   */
+  public function __construct(RecurlyFormatManager $recurly_formatter) {
+    $this->formatter = $recurly_formatter;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('recurly.format_manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -43,10 +71,12 @@ class RecurlyRedeemCouponForm extends FormBase {
     // a new one.
     if ($confirming_replacement_coupon) {
       $form_state->set('confirmed', TRUE);
+      // @todo Get rid of next line. Left to show how it used to be.
+      // $recurly_format_manager = \Drupal::service('recurly.format_manager');
       $help = '<p>' . $this->t('Your account already has a coupon that will be applied to your next invoice. Are you sure you want to replace your existing coupon ":old_coupon" with ":new_coupon"? You may not be able to use your previous coupon again.',
         [
-          ':old_coupon' => recurly_format_coupon($form_state->get('existing_coupon'), $form_state->get('existing_redemption')->currency),
-          ':new_coupon' => recurly_format_coupon($form_state->get('coupon'), $form_state->getValue('coupon_currency')),
+          ':old_coupon' => $this->formatter->formatCoupon($form_state->get('existing_coupon'), $form_state->get('existing_redemption')->currency),
+          ':new_coupon' => $this->formatter->formatCoupon($form_state->get('coupon'), $form_state->getValue('coupon_currency')),
         ]) . '</p>';
     }
     elseif ($account->redemption) {
@@ -54,7 +84,9 @@ class RecurlyRedeemCouponForm extends FormBase {
       $form_state->set('existing_redemption', $existing_coupon_redemption);
       $form_state->set('existing_coupon', $existing_coupon_redemption->coupon->get());
 
-      $help = '<p>' . $this->t('Your next invoice will have the following coupon applied:') . ' <strong>' . recurly_format_coupon($form_state->get('existing_coupon'), $form_state->get('existing_redemption')->currency) . '</strong></p>';
+      // @todo Get rid of next line. Left to show how it used to be.
+      // $recurly_format_manager = \Drupal::service('recurly.format_manager');
+      $help = '<p>' . $this->t('Your next invoice will have the following coupon applied:') . ' <strong>' . $this->formatter->formatCoupon($form_state->get('existing_coupon'), $form_state->get('existing_redemption')->currency) . '</strong></p>';
       $help .= '<p>' . $this->t('Please note that only one coupon can be redeemed per invoice.') . '</p>';
     }
     else {
@@ -167,8 +199,10 @@ class RecurlyRedeemCouponForm extends FormBase {
       drupal_set_message($this->t('Unable to redeem the coupon @code, the coupon may no longer be valid.', ['@code' => $coupon->coupon_code]), 'error');
     }
     else {
+      // @todo Get rid of next line. Left to show how it used to be.
+      // $recurly_format_manager = \Drupal::service('recurly.format_manager');
       drupal_set_message($this->t('The coupon !coupon has been applied to your account and will be redeemed the next time your subscription renews.', [
-        '!coupon' => recurly_format_coupon($coupon, $form_state->getValue(['coupon_currency'])),
+        '!coupon' => $this->formatter->formatCoupon($coupon, $form_state->getValue(['coupon_currency'])),
       ]));
     }
   }

--- a/src/Form/RecurlySettingsForm.php
+++ b/src/Form/RecurlySettingsForm.php
@@ -33,7 +33,7 @@ class RecurlySettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, \Drupal\Core\Form\FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state) {
     // Recommend setting some subscription plans if not enabled.
     $plan_options = \Drupal::config('recurly.settings')->get('recurly_subscription_plans') ?: [];
 
@@ -352,7 +352,7 @@ class RecurlySettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
+  public function validateForm(array &$form, FormStateInterface $form_state) {
     $keys = [
       'recurly_private_api_key',
       'recurly_public_key',
@@ -414,7 +414,7 @@ class RecurlySettingsForm extends ConfigFormBase {
     parent::submitForm($form, $form_state);
   }
 
-  public function _submitForm(array &$form, \Drupal\Core\Form\FormStateInterface $form_state) {
+  public function _submitForm(array &$form, FormStateInterface $form_state) {
     // Rebuild the menu system if any of the built-in page options change.
     foreach ($form_state->get(['pages_previous_values']) as $variable_name => $previous_value) {
       if (!$form_state->getValue([$variable_name]) && $form_state->getValue([$variable_name]) !== $previous_value) {

--- a/src/Form/RecurlySubscriptionPlansForm.php
+++ b/src/Form/RecurlySubscriptionPlansForm.php
@@ -10,11 +10,39 @@ namespace Drupal\recurly\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Utility\SafeMarkup;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\recurly\RecurlyFormatManager;
 
 /**
  * Recurly subscription plans form.
  */
 class RecurlySubscriptionPlansForm extends FormBase {
+
+  /**
+   * The formatting service.
+   *
+   * @var \Drupal\recurly\RecurlyFormatManager
+   */
+  protected $formatter;
+
+  /**
+   * Constructs a \Drupal\recurly\Form\RecurlySubscriptionPlansForm object.
+   *
+   * @param \Drupal\recurly\RecurlyFormatManager $formatter
+   *   The Recurly formatter to be used for formatting.
+   */
+  public function __construct(RecurlyFormatManager $recurly_formatter) {
+    $this->formatter = $recurly_formatter;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('recurly.format_manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -38,6 +66,8 @@ class RecurlySubscriptionPlansForm extends FormBase {
       return $this->t('No plans could be retrieved from Recurly. Recurly reported the following error: "@error"', ['@error' => $e->getMessage()]);
     }
     $form['weights']['#tree'] = TRUE;
+    // @todo Get rid of next line. Left to show how it used to be.
+    // $recurly_format_manager = \Drupal::service('recurly.format_manager');
 
     $plan_options = [];
     $count = 0;
@@ -57,13 +87,13 @@ class RecurlySubscriptionPlansForm extends FormBase {
       foreach ($unit_amounts as $unit_amount) {
         $form['#plans'][$plan->plan_code]['unit_amounts'][$unit_amount->currencyCode] = $this->t('@unit_price every @interval_length @interval_unit',
           [
-            '@unit_price' => recurly_format_currency($unit_amount->amount_in_cents, $unit_amount->currencyCode),
+            '@unit_price' => $this->formatter->formatCurrency($unit_amount->amount_in_cents, $unit_amount->currencyCode),
             '@interval_length' => $plan->plan_interval_length,
             '@interval_unit' => $plan->plan_interval_unit,
           ]);
       }
       foreach ($setup_fees as $setup_fee) {
-        $form['#plans'][$plan->plan_code]['setup_amounts'][$unit_amount->currencyCode] = recurly_format_currency($setup_fee->amount_in_cents, $setup_fee->currencyCode);
+        $form['#plans'][$plan->plan_code]['setup_amounts'][$unit_amount->currencyCode] = $this->formatter->formatCurrency($setup_fee->amount_in_cents, $setup_fee->currencyCode);
       }
       $form['weights'][$plan->plan_code] = [
         '#type' => 'hidden',

--- a/src/RecurlyFormatManager.php
+++ b/src/RecurlyFormatManager.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\recurly\RecurlyFormatManager.
+ */
+
+namespace Drupal\recurly;
+
+/**
+ * Constants for "state" strings.
+ */
+const RECURLY_STATE_ACTIVE = 'active';
+const RECURLY_STATE_CANCELED = 'canceled';
+const RECURLY_STATE_EXPIRED = 'expired';
+const RECURLY_STATE_FUTURE = 'future';
+const RECURLY_STATE_PENDING_SUBSCRIPTION = 'pending_subscription';
+const RECURLY_STATE_IN_TRIAL = 'in_trial';
+const RECURLY_STATE_LIVE = 'live';
+const RECURLY_STATE_PAST_DUE = 'past_due';
+
+class RecurlyFormatManager {
+
+  /**
+   * Format a Recurly subscription state.
+   */
+  function formatState($state) {
+    switch ($state) {
+      case RECURLY_STATE_ACTIVE:
+        return t('Active');
+
+      case RECURLY_STATE_CANCELED:
+        return t('Canceled (will not renew)');
+
+      case RECURLY_STATE_EXPIRED:
+        return t('Expired');
+
+      case RECURLY_STATE_FUTURE:
+        return t('Future Activation');
+
+      case RECURLY_STATE_PENDING_SUBSCRIPTION:
+        return t('Switching to new plan');
+
+      case RECURLY_STATE_IN_TRIAL:
+        return t('Trial');
+
+      case RECURLY_STATE_LIVE:
+        return t('Live');
+
+      case RECURLY_STATE_PAST_DUE:
+        return t('Past Due');
+    }
+  }
+
+
+  /**
+   * Format a date for use in invoices.
+   */
+  function formatDate($date) {
+    $format = \Drupal::config('recurly.settings')->get('recurly_date_format');
+    if (is_object($date)) {
+      $date->setTimezone(new DateTimeZone('UTC'));
+      $timestamp = $date->format('U');
+    }
+    else {
+      $timestamp = strtotime($date);
+    }
+
+    return is_numeric($timestamp) ? format_date($timestamp, $format) : NULL;
+  }
+
+
+  /**
+   * Format a price for display.
+   */
+  function formatCurrency($price_in_cents, $currency, $html = FALSE) {
+    $currencies = recurly_currency_list();
+    $currency_info = isset($currencies[$currency]) ? $currencies[$currency] : ['', ' ' . $currency];
+    $prefix = $currency_info[0] ? $currency_info[0] : '';
+    $suffix = $currency_info[1] ? $currency_info[1] : '';
+    $thousands_separator = isset($currency_info[2]) ? $currency_info[2] : ',';
+    $decimal_separator = isset($currency_info[3]) ? $currency_info[3] : '.';
+    $decimals = isset($currency_info[4]) ? $currency_info[4] : 2;
+    $rounding_step = isset($currency_info[5]) ? $currency_info[5] : NULL;
+
+    // Commerce module provides a more flexible and complete currency formatter.
+    if (\Drupal::moduleHandler()->moduleExists('commerce')) {
+      $formatted = commerce_currency_format($price_in_cents, $currency, NULL, TRUE);
+    }
+    else {
+      // Convert to a decimal amount.
+      $float = $price_in_cents / 100;
+
+      // Round the amount if necessary i.e. Francs round up to the nearest 0.05.
+      if ($rounding_step) {
+        $modifier = 1 / $rounding_step;
+        $float = round($float * $modifier) / $modifier;
+      }
+
+      // Format the number.
+      $formatted = $prefix . number_format($float, $decimals, $decimal_separator, $thousands_separator) . $suffix;
+    }
+
+    // Wrap each part in HTML if requested.
+    if ($html) {
+      $amount_string = '';
+      $amount_array = [];
+      preg_match('/([^0-9]*)?([0-9' . preg_quote($thousands_separator) . ']+)([0-9' . preg_quote($decimal_separator) . ']+)(.*)?/', $formatted, $amount_array);
+      if ($amount_array[1]) {
+        $amount_string .= '<span class="currency-prefix">' . $amount_array[1] . '</span>';
+      }
+      if ($amount_array[2]) {
+        $amount_string .= '<span class="currency-dollars">' . $amount_array[2] . '</span>';
+      }
+      if ($amount_array[3]) {
+        $amount_string .= '<span class="currency-cents">' . $amount_array[3] . '</span>';
+      }
+      if ($amount_array[4]) {
+        $amount_string .= '<span class="currency-suffix">' . $amount_array[4] . '</span>';
+      }
+      $formatted = $amount_string;
+    }
+
+    return $formatted;
+  }
+
+
+  /**
+   * Format an interval of time in a human-readable way.
+   */
+  function formatPriceInterval($amount, $count, $unit, $html = FALSE) {
+    if ($amount === NULL) {
+      if ($unit == 'days') {
+        return \Drupal::translation()->formatPlural($count, '1 day trial', '@count day trial');
+      }
+      else {
+        return \Drupal::translation()->formatPlural($count, '1 month trial', '@count month trial');
+      }
+    }
+
+    $replacements = [
+      '!count' => $html ? '<span class="plan-count">' . SafeMarkup::checkPlain($count) . '<span>' : SafeMarkup::checkPlain($count),
+      '!amount' => $html ? '<span class="plan-amount">' . $amount . '</span>' : $amount,
+    ];
+    if ($count == 1) {
+      switch ($unit) {
+        case 'days':
+          return t('!amount per day', $replacements);
+
+        case 'months':
+          return t('!amount per month', $replacements);
+      }
+    }
+    elseif ($count == 7 && $unit == 'days') {
+      return t('!amount per week', $replacements);
+    }
+    elseif ($count == 12 && $unit == 'months') {
+      return t('!amount per year', $replacements);
+    }
+    else {
+      switch ($unit) {
+        case 'days':
+          return t('!amount every !count days', $replacements);
+
+        case 'months':
+          return t('!amount every !count months', $replacements);
+      }
+    }
+  }
+
+
+  /**
+   * Simple function to print out human-readable transaction status.
+   */
+  function formatTransactionStatus($status) {
+    switch ($status) {
+      case 'success':
+        return t('Successful payment');
+
+      case 'failed':
+        return t('Failed payment');
+
+      case 'voided':
+        return t('Voided');
+
+      case 'declined':
+        return t('Card declined');
+
+      default:
+        return SafeMarkup::checkPlain($status);
+    }
+  }
+
+
+  /**
+   * Format a Recurly coupon in a human-readable string.
+   *
+   * @param \Recurly_Coupon $coupon
+   *   The Recurly coupon object being formatted for display.
+   * @param string $currency
+   *   The currency code in which the coupon is being redeemed.
+   * @param bool $html
+   *   Whether to return the formatted string with wrapping HTML or not.
+   *
+   * @return string
+   *   The formatted string ready for printing.
+   */
+  function formatCoupon(\Recurly_Coupon $coupon, $currency, $html = FALSE) {
+    // @todo. I am not sure about Recurly_Coupon. I do not think that class exists.
+    if ($coupon->discount_type === 'percent') {
+      $amount = SafeMarkup::checkPlain($coupon->discount_percent) . '%';
+    }
+    else {
+      $coupon_currency = $coupon->discount_in_cents[$currency];
+      $amount = $this->formatCurrency($coupon_currency->amount_in_cents, $currency, $html);
+    }
+
+    return SafeMarkup::checkPlain($coupon->name) . ' (' . t('@amount discount', ['@amount' => $amount]) . ')';
+  }
+}


### PR DESCRIPTION
The D7 formatting functions were all in `recurly.module`. This commit creates a formatting service, `RecurlyFormatManager`, that houses the formatting methods. (ex. formatCurrency, formatDate etc.)

The goal is to use dependency injection so that the formatting service is available in the controllers and forms that need them.

For demonstration purposes, the formatting service has been injected into the following:
- `RecurlyRedeemCouponForm`
- `RecurlySubscriptionPlansForm`
- `RecurlySubscriptionListController`

The last one is probably the best example, because that one controller needs to format `State`, `Currency` and `Date`. By using the `RecurlyFormatManager` service, it can all be done through the one object.
