### PR TITLE
Remove fatal error from recurly's hook_entity_update function

### DIFF
--- a/recurly.module
+++ b/recurly.module
@@ -139,6 +139,11 @@ function recurly_entity_update(\Drupal\Core\Entity\EntityInterface $entity) {
 
   // Check if any of the mapping tokens have changed.
   $original_entity = \Drupal::entityManager()->getStorage($entity_type)->load($entity->getOriginalId());
+  // Only makes sense to continue if $original_entity is not null.
+  if (is_null($original_entity)) {
+    return;
+  }
+
   $original_values = [];
   $updated_values = [];
 

--- a/recurly.module
+++ b/recurly.module
@@ -138,9 +138,7 @@ function recurly_entity_update(\Drupal\Core\Entity\EntityInterface $entity) {
   }
 
   // Check if any of the mapping tokens have changed.
-  $original_entity = \Drupal::entityManager()->getStorage($entity_type)->load($entity->getOriginalId());
-  // Only makes sense to continue if $original_entity is not null.
-  if (is_null($original_entity)) {
+  if (!$original_entity = \Drupal::entityManager()->getStorage($entity_type)->load($entity->getOriginalId())) {
     return;
   }
 


### PR DESCRIPTION
After looking at it a while, I resolved that the easiest way to avoid the fatal error is to get out of the function if the instantiated `$original_entity` variable is `NULL`.

`array_flip(): Can only flip STRING and INTEGER values! EntityStorageBase.php:232   [warning]
array_flip(): Can only flip STRING and INTEGER values! EntityStorageBase.php:144   [warning]
Changed password for matsoo                                                        [success]`

I don't think there's anything we can directly to about the `array_flip()` warning.
